### PR TITLE
fix(powercord): use sanitizeDerivationName

### DIFF
--- a/drvs/powercord.nix
+++ b/drvs/powercord.nix
@@ -10,10 +10,7 @@ stdenvNoCC.mkDerivation {
 
   installPhase =
     let
-      sanitise = s:
-        (lib.strings.toLower
-          (lib.strings.replaceStrings [" "] ["-"] s));
-      readName = f: sanitise (builtins.fromJSON (builtins.readFile f)).name;
+      readName = f: lib.strings.sanitizeDerivationName (builtins.fromJSON (builtins.readFile f)).name;
 
       fromDrvs = drvs: mn: builtins.map (drv: {
         inherit (drv) outPath;


### PR DESCRIPTION
This replaces the custom `sanitize` function with the `lib.strings.sanitizeDerivationName` function.

This fixes an issue where the name was not sufficiently sanitized, allowing the `&` symbol to break the name and attempt to run a command instead.