### PR TITLE
fix(powercord): account for removal of license header

### DIFF
--- a/misc/powercord.patch
+++ b/misc/powercord.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Powercord/plugins/pc-moduleManager/index.js b/src/Powercord/plugins/pc-moduleManager/index.js
-index 0cd00cdd545..657396c8565 100644
+index 0cd00cd..657396c 100644
 --- a/src/Powercord/plugins/pc-moduleManager/index.js
 +++ b/src/Powercord/plugins/pc-moduleManager/index.js
 @@ -5,7 +5,7 @@ const { PopoutWindow } = require('powercord/components');
@@ -21,11 +21,10 @@ index 0cd00cdd545..657396c8565 100644
      this._injectSnippets();
      this.loadStylesheet('scss/style.scss');
 diff --git a/src/browserWindow.js b/src/browserWindow.js
-index f845839ebe8..a5689c37a31 100644
+index 27e87cb..eb7171f 100644
 --- a/src/browserWindow.js
 +++ b/src/browserWindow.js
-@@ -6,12 +6,13 @@
- 
+@@ -1,11 +1,12 @@
  const { join } = require('path');
  const { BrowserWindow } = require('electron');
 +const { SETTINGS_FOLDER } = require('./fake_node_modules/powercord/constants');
@@ -40,7 +39,7 @@ index f845839ebe8..a5689c37a31 100644
    ewp = settings.experimentalWebPlatform;
  } catch (e) {}
 diff --git a/src/fake_node_modules/powercord/constants.js b/src/fake_node_modules/powercord/constants.js
-index 06403b84f23..14922a2432f 100644
+index dc25a15..80d8b24 100644
 --- a/src/fake_node_modules/powercord/constants.js
 +++ b/src/fake_node_modules/powercord/constants.js
 @@ -13,9 +13,9 @@ module.exports = Object.freeze({


### PR DESCRIPTION
Due to the Powercord repository removing license headers from files, the offsets for the patch were incorrect, leading Nix to throw a build error during the patch phase.

Updated the patch file to account for this.