### PR TITLE
fix: inherit discord-canary.meta.mainProgram

### DIFF
--- a/drvs/discord.nix
+++ b/drvs/discord.nix
@@ -14,6 +14,10 @@ symlinkJoin {
   name = "discord-plugged";
   paths = [ discord-canary.out ];
 
+  meta = {
+    inherit (discord-canary.meta) mainProgram;
+  };
+
   postBuild = ''
     cp -r ${inputs.self}/plugs $out/opt/DiscordCanary/resources/app
     substituteInPlace $out/opt/DiscordCanary/resources/app/index.js --replace 'POWERCORD_SRC' '${powercordWithAddons}'


### PR DESCRIPTION
Allows `nix run` to work properly.

This has been in my personal patches for a little while now, so thought to finally PR it.